### PR TITLE
Add requirement.txt to help installing all required packages

### DIFF
--- a/mlr_backend/requirements.txt
+++ b/mlr_backend/requirements.txt
@@ -1,0 +1,10 @@
+Flask==2.2.2
+Flask-Caching==2.0.1
+Flask-Cors==3.0.10
+Flask-JWT==0.3.2
+Flask-RESTful==0.3.9
+numpy==1.23.3
+pandas==1.5.0
+pytest==7.1.3
+requests==2.28.1
+sklearn==0.0


### PR DESCRIPTION
This doesn't directly support a feature but developers.

When merged, a developer may use one line command `pip install -r requirements.txt` to install all the required packages after activating venv.