### PR TITLE
Fix to predictHierClustering returning proper data prediction labels.

### DIFF
--- a/mlr_backend/hierCluster.py
+++ b/mlr_backend/hierCluster.py
@@ -10,7 +10,8 @@ def generateHierClustingModel(data, seed=None, clusters=2):
     # prediction = fit_predict(data)
     return clustering
 
-# Uses the model to predict the placement of the input data
-def predictHierClustering(model, data):
-    predictions = model.predict(data)
+
+# Returns the assigned clusters of datapoints in model
+def predictHierClustering(model):
+    predictions = model.labels_
     return predictions


### PR DESCRIPTION
Fix to not requiring data for the second time and actually return the proper cluster labels for data.

Fixed structure to match unsupervised learning.