### PR TITLE
Add tab card for auth page

### DIFF
--- a/mlr_frontend/package.json
+++ b/mlr_frontend/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.0",
+    "react-tabs": "^6.0.0",
     "react-transition-group": "^4.4.5",
     "web-vitals": "^2.1.4"
   },

--- a/mlr_frontend/src/pages/AuthPage/AuthPage.js
+++ b/mlr_frontend/src/pages/AuthPage/AuthPage.js
@@ -4,8 +4,7 @@ import './AuthPage.css';
 
 import { Navbar, Nav, Container } from 'react-bootstrap';
 import Card from '../../components/Card/Card';
-import Signup from "./Signup";
-import Signin from "./Signin";
+import AuthTab from './AuthTab';
 
 const AuthPage = () => {
   return (
@@ -27,9 +26,7 @@ const AuthPage = () => {
       <div className="authentication_container">
         <Card className="authentication">
           <h2>Authentication Page</h2>
-          <hr />
-          <Signup />
-          <Signin />
+          <AuthTab />
         </Card>
       </div>
     </React.Fragment>

--- a/mlr_frontend/src/pages/AuthPage/AuthTab.js
+++ b/mlr_frontend/src/pages/AuthPage/AuthTab.js
@@ -1,0 +1,23 @@
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import 'react-tabs/style/react-tabs.css';
+import Signup from "./Signup";
+import Signin from "./Signin";
+
+const AuthTab = () => (
+  <Tabs>
+    <TabList>
+      <Tab>Sign In</Tab>
+      <Tab>Sign Up</Tab>
+    </TabList>
+
+    <TabPanel>
+      <Signin />
+    </TabPanel>
+    <TabPanel>
+      <Signup />
+    </TabPanel>
+  </Tabs>
+);
+
+export default AuthTab;
+


### PR DESCRIPTION
This change brings separation of user sign in and user sign up on same page but in different tabs. Users will be able to better recognize whether they are signing up or singing in.