### PR TITLE
Enable login from about

### DIFF
--- a/mlr_frontend/src/pages/AboutPage/AboutPage.js
+++ b/mlr_frontend/src/pages/AboutPage/AboutPage.js
@@ -16,7 +16,7 @@ const HomePage = () => {
                         <Nav.Link className="nav-content-text" href="/about" >
                             About
                         </Nav.Link>
-                        <Nav.Link className="nav-content-text" href="/auth" disabled="true">
+                        <Nav.Link className="nav-content-text" href="/auth" >
                             Log In
                         </Nav.Link>
                         <Nav.Link className="nav-content-text" href="/upload">


### PR DESCRIPTION
I don't see a reason to disable login from about page. Thus, enabling user login/signup from the navbar of about page